### PR TITLE
Update BoxDrive.tkape

### DIFF
--- a/Targets/Apps/BoxDrive.tkape
+++ b/Targets/Apps/BoxDrive.tkape
@@ -7,13 +7,21 @@ Targets:
     -
         Name: Box User Files
         Category: Apps
-        Path: C:\Users\*\Box*\
+        Path: C:\Users\*\Box
         IsDirectory: True
         Recursive: True
         FollowReparsePoint: True
         FollowSymbolicLinks: True
         Comment: "Caution -- This target will collect Box Drive contents from the local drive AND on-demand cloud files. Ensure your scope of authority permits cloud collections before use"
-    -
+   -
+        Name: Box Sync User Files
+        Category: Apps
+        Path: C:\Users\*\Box Sync\
+        IsDirectory: True
+        Recursive: True
+        FollowReparsePoint: True
+        FollowSymbolicLinks: True
+   -
         Name: Box Drive Application Metadata
         Category: Apps
         Path: C:\Users\*\AppData\Local\Box\Box\*\


### PR DESCRIPTION
Removed wildcard on Box folder to reduce false positive matches and explicitly added Box Sync collection for older versions of the Box client